### PR TITLE
export CKK_BIP32 and use in tests

### DIFF
--- a/bip32.go
+++ b/bip32.go
@@ -102,6 +102,9 @@ CK_RV DeriveBIP32Child(struct ctx * c, CK_SESSION_HANDLE session,
 */
 import "C"
 
+// CKK_BIP32 should be assigned to the CKA_KEY_TYPE attribute of templates for derived keys
+const CKK_BIP32 = CKK_VENDOR_DEFINED + 0x14
+
 func (c *Ctx) DeriveBIP32MasterKeys(sh SessionHandle, basekey ObjectHandle, publicAttr []*Attribute, privateAttr []*Attribute) (ObjectHandle, ObjectHandle, error) {
   var publicKey C.CK_OBJECT_HANDLE
   var privateKey C.CK_OBJECT_HANDLE

--- a/bip32_test.go
+++ b/bip32_test.go
@@ -51,6 +51,7 @@ func deriveMasterKeyPair(p *Ctx, session SessionHandle, seed ObjectHandle) (Obje
 
 	publicTemplate := []*Attribute{
 		NewAttribute(CKA_TOKEN, true),
+		NewAttribute(CKA_KEY_TYPE, CKK_BIP32),
 		NewAttribute(CKA_PRIVATE, true),
 		NewAttribute(CKA_ENCRYPT, true),
 		NewAttribute(CKA_VERIFY, true),
@@ -60,6 +61,7 @@ func deriveMasterKeyPair(p *Ctx, session SessionHandle, seed ObjectHandle) (Obje
 
 	privateTemplate := []*Attribute{
 		NewAttribute(CKA_TOKEN, true),
+		NewAttribute(CKA_KEY_TYPE, CKK_BIP32),
 		NewAttribute(CKA_PRIVATE, true),
 		NewAttribute(CKA_DECRYPT, true),
 		NewAttribute(CKA_SIGN, true),
@@ -75,6 +77,7 @@ func deriveChildKeyPair(p *Ctx, session SessionHandle, masterPrivate ObjectHandl
 
 	publicTemplate := []*Attribute{
 		NewAttribute(CKA_TOKEN, false),
+		NewAttribute(CKA_KEY_TYPE, CKK_BIP32),
 		NewAttribute(CKA_PRIVATE, true),
 		NewAttribute(CKA_ENCRYPT, true),
 		NewAttribute(CKA_VERIFY, true),
@@ -84,6 +87,7 @@ func deriveChildKeyPair(p *Ctx, session SessionHandle, masterPrivate ObjectHandl
 
 	privateTemplate := []*Attribute{
 		NewAttribute(CKA_TOKEN, false),
+		NewAttribute(CKA_KEY_TYPE, CKK_BIP32),
 		NewAttribute(CKA_PRIVATE, true),
 		NewAttribute(CKA_DECRYPT, true),
 		NewAttribute(CKA_SIGN, true),


### PR DESCRIPTION
Without setting `CKA_KEY_TYPE` to `CKK_BIP32` in templates for BIP32 key derivation, the derivations will fail with error `0xD0: CKR_TEMPLATE_INCOMPLETE`.